### PR TITLE
Made parsing methods a little DRYer.

### DIFF
--- a/src/main/java/me/grison/jtoml/Toml.java
+++ b/src/main/java/me/grison/jtoml/Toml.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 
 /**
  * Toml parsing class front-end.
- * 
+ *
  * <code>
  *     Toml toml = Toml.parse("pi = 3.141592653589793");
  *     Double pi = toml.getDouble("pi");
@@ -51,7 +51,7 @@ public class Toml implements Parser, Getter {
 
 	@Override
 	public Toml parseFile(File file) throws FileNotFoundException {
-		context = TomlParser.parse(Util.FileToString.read(file));
+		parseString(Util.FileToString.read(file));
 		return this;
 	}
 


### PR DESCRIPTION
The call to TomlParser.parse is now only made in one place.
